### PR TITLE
Open platform effect errors and publish docs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -112,6 +112,33 @@ jobs:
       - name: Run tests with bundled platform
         run: ci/test_bundled_examples.sh "${{ needs.build-and-bundle.outputs.bundle_filename }}"
 
+  build-docs:
+    name: Build Platform Docs
+    runs-on: ubuntu-24.04
+    defaults:
+      run:
+        shell: bash
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Roc nightly
+        uses: roc-lang/setup-roc@cbe782d6f165b89c87d99f50a59ac4f5f73b4427
+        with:
+          version: nightly-new-compiler
+
+      - name: Generate docs
+        run: |
+          roc docs platform/main.roc --output=generated-docs --no-cache
+          touch generated-docs/.nojekyll
+
+      - name: Upload docs artifact
+        if: github.event_name == 'workflow_dispatch'
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: generated-docs
+
   create-release:
     name: Create GitHub Release
     needs: [build-and-bundle, test-bundle]
@@ -150,3 +177,20 @@ jobs:
 
           echo "Release created: ${{ github.event.inputs.release_tag }}"
           echo "Bundle uploaded: $BUNDLE_FILE"
+
+  deploy-docs:
+    name: Deploy Docs to GitHub Pages
+    needs: [build-docs, create-release]
+    runs-on: ubuntu-24.04
+    if: github.event_name == 'workflow_dispatch'
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+      - name: Deploy docs
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+[![Roc-Lang][roc_badge]][roc_link]
+
+[roc_badge]: https://img.shields.io/endpoint?url=https%3A%2F%2Fpastebin.com%2Fraw%2FcFzuCCd7
+[roc_link]: https://github.com/roc-lang/roc
+
 # Roc platform template for Zig
 
 A template for building [Roc platforms](https://www.roc-lang.org/platforms) using [Zig](https://ziglang.org).
@@ -9,15 +14,27 @@ A template for building [Roc platforms](https://www.roc-lang.org/platforms) usin
 
 ## Examples
 
-Use the current release bundle as the platform dependency:
+The examples in this repo use the local platform at `../platform/main.roc`.
 
-```roc
-app [main!] { pf: platform "https://github.com/lukewilliamboswell/roc-platform-template-zig/releases/download/0.9/8GdFEvQYS3TeAZxKvTzCLVdQiomweGtXcdZkXNDEeABq.tar.zst" }
+For apps outside this repo, build a bundle from this checkout and use that generated bundle URL or file path as the platform dependency. The latest published release bundle may not match the current platform API.
+
+```bash
+./bundle.sh
 ```
 
 Run examples with interpreter: `roc examples/<name>.roc`
 
 Build standalone executable: `roc build examples/<name>.roc`
+
+## Documentation
+
+Platform API docs are published at <https://lukewilliamboswell.github.io/roc-platform-template-zig/>.
+
+Generate docs locally:
+
+```bash
+zig build docs
+```
 
 ## Testing
 

--- a/build.zig
+++ b/build.zig
@@ -109,8 +109,20 @@ pub fn build(b: *std.Build) void {
     native_step.dependOn(&copy_native.step);
     native_step.dependOn(&native_lib.step);
 
+    // Docs step: verify Roc docs generation for the platform API.
+    const docs_step = b.step("docs", "Generate Roc platform API docs");
+    const docs = b.addSystemCommand(&.{
+        "roc",
+        "docs",
+        "platform/main.roc",
+        "--output=.zig-cache/roc-docs",
+        "--no-cache",
+    });
+    docs_step.dependOn(&docs.step);
+
     // Test step: run unit tests and integration tests
     const test_step = b.step("test", "Run all tests (unit tests and integration tests)");
+    test_step.dependOn(&docs.step);
 
     // Unit tests for platform code
     const host_tests = b.addTest(.{

--- a/examples/all_roc_syntax.roc
+++ b/examples/all_roc_syntax.roc
@@ -1,4 +1,4 @@
-app [main!] { pf: platform "https://github.com/lukewilliamboswell/roc-platform-template-zig/releases/download/0.9/8GdFEvQYS3TeAZxKvTzCLVdQiomweGtXcdZkXNDEeABq.tar.zst" }
+app [main!] { pf: platform "../platform/main.roc" }
 
 import pf.Stdout
 import pf.Stdout as StdoutAlias
@@ -95,7 +95,7 @@ multiline_str = |number|
 
 # end name with `!` for effectful functions
 # `=>` shows effectfulness in the type signature
-effect_demo! : Str => {}
+effect_demo! : Str => Try({}, [StdoutErr(Str), ..])
 effect_demo! = |msg|
 	Stdout.line!(msg)
 
@@ -149,6 +149,7 @@ while_loop = |limit| {
 	$sum
 }
 
+print! : _ => Try({}, [StdoutErr(Str), ..])
 print! = |something| {
 	Stdout.line!(Str.inspect(something))
 }
@@ -317,85 +318,86 @@ letter_to_str = |letter| match letter {
 stringify : a -> Str where [a.to_str : a -> Str]
 stringify = |value| value.to_str()
 
+main! : List(Str) => Try({}, [Exit(I32), StdoutErr(Str), ..])
 main! = |_args| {
-	Stdout.line!("Hello, world!")
-	StdoutAlias.line!("Hello, world! (using alias)")
+	Stdout.line!("Hello, world!")?
+	StdoutAlias.line!("Hello, world! (using alias)")?
 
-	Stdout.line!(Str.inspect(number_operators(10, 5)))
-	print!(boolean_operators(Bool.True, Bool.False))
+	Stdout.line!(Str.inspect(number_operators(10, 5)))?
+	print!(boolean_operators(Bool.True, Bool.False))?
 
 	# pizza operator (|>) is gone, we now have static dispatch instead.
 	# It allows you to call methods that are defined on the type (like `Animal.is_eq` above).
-	print!("One".concat(" Two"))
+	print!("One".concat(" Two"))?
 
 	# If you want a very similar style for a function that is not defined on the type but is in scope, you can use `->`:
-	print!("Three"->my_concat(" Four"))
+	print!("Three"->my_concat(" Four"))?
 
-	Stdout.line!(simple_match(Red))
-	print!(match_list_patterns([1, 10]))
-	Stdout.line!(match_tag_union_advanced(Ok({})))
+	Stdout.line!(simple_match(Red))?
+	print!(match_list_patterns([1, 10]))?
+	Stdout.line!(match_tag_union_advanced(Ok({})))?
 
-	Stdout.line!(multiline_str(3))
-	Stdout.line!("Unicode escape sequence: \u(00A0)")
+	Stdout.line!(multiline_str(3))?
+	Stdout.line!("Unicode escape sequence: \u(00A0)")?
 
-	effect_demo!("This is an effectful function!")
+	effect_demo!("This is an effectful function!")?
 
 	#Stdout.line!(Str.inspect(question_postfix(["1", "not a number", "100"])))
 
 	sum = for_loop([1, 2, 3, 4, 5])
-	print!(sum)
+	print!(sum)?
 
 	expect sum == 15
 
 	all_true = break_in_for_loop([True, True, False, True, True])
-	print!(all_true)
+	print!(all_true)?
 
     while_sum = while_loop(5)
-	print!(while_sum)
+	print!(while_sum)?
 
-	print!(dbg_keyword())
+	print!(dbg_keyword())?
 
-	Stdout.line!(if_demo(2))
+	Stdout.line!(if_demo(2))?
 
-	print!(tuple_demo)
+	print!(tuple_demo)?
 
-	print!(type_var(["a", "b"]))
+	print!(type_var(["a", "b"]))?
 
-	print!(destructuring())
+	print!(destructuring())?
 
 	# print!(record_update)
 
-	print!({ x: 10, y: 20 }.x)
+	print!({ x: 10, y: 20 }.x)?
 
-	print!(record_update_2({ name: "Alice", age: 30 }))
+	print!(record_update_2({ name: "Alice", age: 30 }))?
 
-	print!(number_literals)
+	print!(number_literals)?
 
 	secret = Secret.new("my_secret_key")
 	# This print will not expose internal data.
-	print!(secret)
-	print!(secret.unlock("open sesame"))
+	print!(secret)?
+	print!(secret.unlock("open sesame"))?
 
 	dog : Animal
 	dog = Dog("Fido")
 	cat : Animal
 	cat = Cat("Whiskers")
-	print!(dog == cat)
+	print!(dog == cat)?
 
-	print!(early_return(Bool.False))
+	print!(early_return(Bool.False))?
 
-	print!(stringify(12345))
+	print!(stringify(12345))?
 
 	# Tags with multiple payloads
-	print!(multi_payload_tag(Foo(42, "hello")))
+	print!(multi_payload_tag(Foo(42, "hello")))?
 
 	# Open tag unions with `..`
 	# This function accepts [Red, Green, ..] so we can pass Blue too
-	print!(color_to_str(Blue))
+	print!(color_to_str(Blue))?
 
 	# Type alias for extensible tag union
-	print!(letter_to_str(A))
-	print!(letter_to_str(C)) # C is not in [A, B] but we passed it in the signature of letter_to_str
+	print!(letter_to_str(A))?
+	print!(letter_to_str(C))? # C is not in [A, B] but we passed it in the signature of letter_to_str
 
 	# TODO Stdout.line!(readme);
 
@@ -405,5 +407,5 @@ main! = |_args| {
 	Ok({})
 }
 
-# Top level expects only run when using `roc test file.roc`
+## Top-level expects run when using `roc test file.roc`.
 expect Bool.True != Bool.False

--- a/examples/cli_args.roc
+++ b/examples/cli_args.roc
@@ -1,13 +1,13 @@
-app [main!] { pf: platform "https://github.com/lukewilliamboswell/roc-platform-template-zig/releases/download/0.9/8GdFEvQYS3TeAZxKvTzCLVdQiomweGtXcdZkXNDEeABq.tar.zst" }
+app [main!] { pf: platform "../platform/main.roc" }
 
 import pf.Stdout
 
-main! : List(Str) => Try({}, [Exit(I32)])
+main! : List(Str) => Try({}, [Exit(I32), StdoutErr(Str), ..])
 main! = |args| {
-    Stdout.line!("Hello Roc!")
+    Stdout.line!("Hello Roc!")?
 
     args_str = Str.join_with(args, ", ")
-    Stdout.line!("Args: ${args_str}")
+    Stdout.line!("Args: ${args_str}")?
 
     Ok({})
 }

--- a/examples/dbg_test.roc
+++ b/examples/dbg_test.roc
@@ -1,9 +1,10 @@
-app [main!] { pf: platform "https://github.com/lukewilliamboswell/roc-platform-template-zig/releases/download/0.9/8GdFEvQYS3TeAZxKvTzCLVdQiomweGtXcdZkXNDEeABq.tar.zst" }
+app [main!] { pf: platform "../platform/main.roc" }
 
 import pf.Stdout
 
+main! : List(Str) => Try({}, [Exit(I32), StdoutErr(Str), ..])
 main! = |_args| {
     dbg "test message"
-    Stdout.line!("stdout works")
+    Stdout.line!("stdout works")?
     Ok({})
 }

--- a/examples/echo.roc
+++ b/examples/echo.roc
@@ -1,16 +1,16 @@
-app [main!] { pf: platform "https://github.com/lukewilliamboswell/roc-platform-template-zig/releases/download/0.9/8GdFEvQYS3TeAZxKvTzCLVdQiomweGtXcdZkXNDEeABq.tar.zst" }
+app [main!] { pf: platform "../platform/main.roc" }
 
 import pf.Stdin
 import pf.Stdout
 
 # Demonstrates: Stdin.line!, interactive I/O, effectful functions
 
-main! : List(Str) => Try({}, [Exit(I32)])
+main! : List(Str) => Try({}, [Exit(I32), StdinErr(Str), StdoutErr(Str), ..])
 main! = |_args| {
-    Stdout.line!("Enter something and I'll echo it back:")
+    Stdout.line!("Enter something and I'll echo it back:")?
 
-    input = Stdin.line!()
-    Stdout.line!("You entered: ${input}")
+    input = Stdin.line!({})?
+    Stdout.line!("You entered: ${input}")?
 
     Ok({})
 }

--- a/examples/echo_multiline.roc
+++ b/examples/echo_multiline.roc
@@ -1,18 +1,18 @@
-app [main!] { pf: platform "https://github.com/lukewilliamboswell/roc-platform-template-zig/releases/download/0.9/8GdFEvQYS3TeAZxKvTzCLVdQiomweGtXcdZkXNDEeABq.tar.zst" }
+app [main!] { pf: platform "../platform/main.roc" }
 
 import pf.Stdin
 import pf.Stdout
 
 # Demonstrates: Reading multiline input from stdin until EOF, while loops, for loops, List.append
 
-main! : List(Str) => Try({}, [Exit(I32)])
+main! : List(Str) => Try({}, [Exit(I32), StdinErr(Str), StdoutErr(Str), ..])
 main! = |_args| {
     var $lines = []
     var $continue = True
 
     # Read all lines from stdin until EOF (which returns empty string)
     while $continue {
-        line = Stdin.line!()
+        line = Stdin.line!({})?
 
         # Empty string indicates EOF
         if line == "" {
@@ -24,7 +24,7 @@ main! = |_args| {
 
     # Echo all lines back
     for line in $lines {
-        Stdout.line!(line)
+        Stdout.line!(line)?
     }
 
     Ok({})

--- a/examples/exit.roc
+++ b/examples/exit.roc
@@ -1,9 +1,9 @@
-app [main!] { pf: platform "https://github.com/lukewilliamboswell/roc-platform-template-zig/releases/download/0.9/8GdFEvQYS3TeAZxKvTzCLVdQiomweGtXcdZkXNDEeABq.tar.zst" }
+app [main!] { pf: platform "../platform/main.roc" }
 
 import pf.Stdout
 
-main! : List(Str) => Try({}, [Exit(I32)])
+main! : List(Str) => Try({}, [Exit(I32), StdoutErr(Str), ..])
 main! = |_args| {
-    Stdout.line!("This example exits with a non-zero exit code")
+    Stdout.line!("This example exits with a non-zero exit code")?
     Err(Exit(23))
 }

--- a/examples/fizzbuzz.roc
+++ b/examples/fizzbuzz.roc
@@ -1,16 +1,16 @@
-app [main!] { pf: platform "https://github.com/lukewilliamboswell/roc-platform-template-zig/releases/download/0.9/8GdFEvQYS3TeAZxKvTzCLVdQiomweGtXcdZkXNDEeABq.tar.zst" }
+app [main!] { pf: platform "../platform/main.roc" }
 
 import pf.Stdout
 
 # Demonstrates: while loops, var/$variables, pattern matching
 
-main! : List(Str) => Try({}, [Exit(I32)])
+main! : List(Str) => Try({}, [Exit(I32), StdoutErr(Str), ..])
 main! = |_args| {
     var $n = 1
 
     while $n <= 15 {
         output = fizzbuzz($n)
-        Stdout.line!(output)
+        Stdout.line!(output)?
         $n = $n + 1
     }
 

--- a/examples/hello_world.roc
+++ b/examples/hello_world.roc
@@ -1,8 +1,9 @@
-app [main!] { pf: platform "https://github.com/lukewilliamboswell/roc-platform-template-zig/releases/download/0.9/8GdFEvQYS3TeAZxKvTzCLVdQiomweGtXcdZkXNDEeABq.tar.zst" }
+app [main!] { pf: platform "../platform/main.roc" }
 
 import pf.Stdout
 
+main! : List(Str) => Try({}, [Exit(I32), StdoutErr(Str), ..])
 main! = |_args| {
-    Stdout.line!("Hello, World!")
+    Stdout.line!("Hello, World!")?
     Ok({})
 }

--- a/examples/match.roc
+++ b/examples/match.roc
@@ -1,10 +1,10 @@
-app [main!] { pf: platform "https://github.com/lukewilliamboswell/roc-platform-template-zig/releases/download/0.9/8GdFEvQYS3TeAZxKvTzCLVdQiomweGtXcdZkXNDEeABq.tar.zst" }
+app [main!] { pf: platform "../platform/main.roc" }
 
 import pf.Stdout
 
 # Demonstrates: match expressions on booleans
 
-main! : List(Str) => Try({}, [Exit(I32)])
+main! : List(Str) => Try({}, [Exit(I32), StdoutErr(Str), ..])
 main! = |args| {
     # Pattern match on booleans derived from command-line input
     no_extra_args = args.len() == 1
@@ -14,13 +14,13 @@ main! = |args| {
         True => "yes"
         False => "no"
     }
-    Stdout.line!("match no extra args: ${result1}")
+    Stdout.line!("match no extra args: ${result1}")?
 
     result2 = match has_extra_args {
         True => "yes"
         False => "no"
     }
-    Stdout.line!("match extra args: ${result2}")
+    Stdout.line!("match extra args: ${result2}")?
 
     Ok({})
 }

--- a/examples/stderr.roc
+++ b/examples/stderr.roc
@@ -1,19 +1,19 @@
-app [main!] { pf: platform "https://github.com/lukewilliamboswell/roc-platform-template-zig/releases/download/0.9/8GdFEvQYS3TeAZxKvTzCLVdQiomweGtXcdZkXNDEeABq.tar.zst" }
+app [main!] { pf: platform "../platform/main.roc" }
 
 import pf.Stdout
 import pf.Stderr
 
 # Demonstrates: Stderr output, both output streams
 
-main! : List(Str) => Try({}, [Exit(I32)])
+main! : List(Str) => Try({}, [Exit(I32), StderrErr(Str), StdoutErr(Str), ..])
 main! = |_args| {
     # Write to stdout
-    Stdout.line!("This message goes to stdout")
-    Stdout.line!("You can redirect it with: roc run example.roc > out.txt")
+    Stdout.line!("This message goes to stdout")?
+    Stdout.line!("You can redirect it with: roc run example.roc > out.txt")?
 
     # Write to stderr
-    Stderr.line!("This message goes to stderr")
-    Stderr.line!("You can redirect it with: roc run example.roc 2> err.txt")
+    Stderr.line!("This message goes to stderr")?
+    Stderr.line!("You can redirect it with: roc run example.roc 2> err.txt")?
 
     # Return success
     Ok({})

--- a/examples/sum_fold.roc
+++ b/examples/sum_fold.roc
@@ -1,19 +1,19 @@
-app [main!] { pf: platform "https://github.com/lukewilliamboswell/roc-platform-template-zig/releases/download/0.9/8GdFEvQYS3TeAZxKvTzCLVdQiomweGtXcdZkXNDEeABq.tar.zst" }
+app [main!] { pf: platform "../platform/main.roc" }
 
 import pf.Stdout
 
 # Demonstrates: fold, pure functions, lambdas
 # NOTE: Some fold operations with numbers have compiler bugs
 
-main! : List(Str) => Try({}, [Exit(I32)])
+main! : List(Str) => Try({}, [Exit(I32), StdoutErr(Str), ..])
 main! = |_args| {
     # Build a string using fold - concatenate list items
     joined = ["Hello", " ", "World", "!"].fold("", |acc, s| Str.concat(acc, s))
-    Stdout.line!("Joined: ${joined}")
+    Stdout.line!("Joined: ${joined}")?
 
     # Use Str.join_with for joining with separator
     csv = Str.join_with(["apple", "banana", "cherry"], ", ")
-    Stdout.line!("Fruits: ${csv}")
+    Stdout.line!("Fruits: ${csv}")?
 
     Ok({})
 }

--- a/examples/tests.roc
+++ b/examples/tests.roc
@@ -1,4 +1,4 @@
-app [main!] { pf: platform "https://github.com/lukewilliamboswell/roc-platform-template-zig/releases/download/0.9/8GdFEvQYS3TeAZxKvTzCLVdQiomweGtXcdZkXNDEeABq.tar.zst" }
+app [main!] { pf: platform "../platform/main.roc" }
 
 import pf.Stdout
 
@@ -6,25 +6,37 @@ import pf.Stdout
 # Run with: roc test examples/tests.roc
 # NOTE: Type annotations on helper functions cause compiler panic
 
-main! : List(Str) => Try({}, [Exit(I32)])
+main! : List(Str) => Try({}, [Exit(I32), StdoutErr(Str), ..])
 main! = |_args| {
-    Stdout.line!("Run 'roc test --verbose examples/tests.roc' to execute the tests")
+    Stdout.line!("Run 'roc test --verbose examples/tests.roc' to execute the tests")?
     Ok({})
 }
 
 # --- Simple expects for demonstration ---
 
-# Basic arithmetic
+## Addition works for small integers.
 expect 1 + 1 == 2
+
+## Subtraction works for small integers.
 expect 10 - 3 == 7
+
+## Multiplication works for small integers.
 expect 4 * 5 == 20
 
-# Boolean logic
+## True equals itself.
 expect True == True
+
+## False equals itself.
 expect False == False
+
+## True and False are distinct values.
 expect True != False
 
-# String operations
+## Strings can be concatenated.
 expect Str.concat("Hello", " World") == "Hello World"
+
+## Empty strings report as empty.
 expect Str.is_empty("")
+
+## Non-empty strings do not report as empty.
 expect Str.is_empty("hi") == False

--- a/platform/Host.roc
+++ b/platform/Host.roc
@@ -1,0 +1,8 @@
+## Internal hosted-effect boundary used by the platform wrappers.
+##
+## Applications should import `Stdout`, `Stderr`, and `Stdin` instead.
+Host := [].{
+	stderr_line! : Str => Try({}, [StderrErr(Str)])
+	stdin_line! : {} => Try(Str, [StdinErr(Str)])
+	stdout_line! : Str => Try({}, [StdoutErr(Str)])
+}

--- a/platform/Stderr.roc
+++ b/platform/Stderr.roc
@@ -1,3 +1,14 @@
+import Host
+
+## Utilities for writing to [standard error](https://en.wikipedia.org/wiki/Standard_streams#Standard_error_(stderr)).
 Stderr := [].{
-    line! : Str => {}
+    ## Write the given string to standard error, followed by a newline.
+    ##
+    ## Returns `Err(StderrErr(message))` if the host cannot write to stderr.
+    line! : Str => Try({}, [StderrErr(Str), ..])
+    line! = |message|
+        match Host.stderr_line!(message) {
+            Ok({}) => Ok({})
+            Err(StderrErr(err)) => Err(StderrErr(err))
+        }
 }

--- a/platform/Stdin.roc
+++ b/platform/Stdin.roc
@@ -1,3 +1,17 @@
+import Host
+
+## Utilities for reading from [standard input](https://en.wikipedia.org/wiki/Standard_streams#Standard_input_(stdin)).
 Stdin := [].{
-    line! : () => Str
+    ## Read one line from standard input.
+    ##
+    ## The returned string does not include the trailing newline. On EOF this returns
+    ## an empty string.
+    ##
+    ## Returns `Err(StdinErr(message))` if the host cannot read from stdin.
+    line! : {} => Try(Str, [StdinErr(Str), ..])
+    line! = |{}|
+        match Host.stdin_line!({}) {
+            Ok(line) => Ok(line)
+            Err(StdinErr(err)) => Err(StdinErr(err))
+        }
 }

--- a/platform/Stdout.roc
+++ b/platform/Stdout.roc
@@ -1,3 +1,14 @@
+import Host
+
+## Utilities for writing to [standard output](https://en.wikipedia.org/wiki/Standard_streams#Standard_output_(stdout)).
 Stdout := [].{
-    line! : Str => {}
+    ## Write the given string to standard output, followed by a newline.
+    ##
+    ## Returns `Err(StdoutErr(message))` if the host cannot write to stdout.
+    line! : Str => Try({}, [StdoutErr(Str), ..])
+    line! = |message|
+        match Host.stdout_line!(message) {
+            Ok({}) => Ok({})
+            Err(StdoutErr(err)) => Err(StdoutErr(err))
+        }
 }

--- a/platform/main.roc
+++ b/platform/main.roc
@@ -1,12 +1,12 @@
 platform ""
-    requires {} { main! : List(Str) => Try({}, [Exit(I32)]) }
+    requires {} { main! : List(Str) => Try({}, [Exit(I32), ..]) }
     exposes [Stdout, Stderr, Stdin]
     packages {}
     provides { "roc_main": main_for_host! }
     hosted {
-        "roc_stderr_line": Stderr.line!,
-        "roc_stdin_line": Stdin.line!,
-        "roc_stdout_line": Stdout.line!,
+        "roc_stderr_line": Host.stderr_line!,
+        "roc_stdin_line": Host.stdin_line!,
+        "roc_stdout_line": Host.stdout_line!,
     }
     targets: {
         inputs_dir: "targets/",
@@ -21,6 +21,7 @@ platform ""
 import Stdout
 import Stderr
 import Stdin
+import Host
 
 main_for_host! : List(Str) => I32
 main_for_host! = |args| {
@@ -28,5 +29,9 @@ main_for_host! = |args| {
     match result {
         Ok({}) => 0
         Err(Exit(code)) => code
+        Err(other) => {
+            _ = Stderr.line!("ERROR: ${Str.inspect(other)}")
+            -1
+        }
     }
 }

--- a/src/host.zig
+++ b/src/host.zig
@@ -44,8 +44,48 @@ fn main(argc: c_int, argv: [*][*:0]u8) callconv(.c) c_int {
     return platform_main(@intCast(argc), argv);
 }
 
-/// Hosted function: Stderr.line!
-fn hostedStderrLine(str: abi.RocStr) callconv(.c) void {
+fn stderrLineOk() abi.TryType0 {
+    var result = std.mem.zeroes(abi.TryType0);
+    result.tag = .Ok;
+    return result;
+}
+
+fn stderrLineErr(err: anyerror, roc_host: *abi.RocHost) abi.TryType0 {
+    var result = std.mem.zeroes(abi.TryType0);
+    result.payload = .{ .err = abi.RocStr.fromSlice(@errorName(err), roc_host) };
+    result.tag = .Err;
+    return result;
+}
+
+fn stdinLineOk(line: abi.RocStr) abi.TryType4 {
+    var result = std.mem.zeroes(abi.TryType4);
+    result.payload = .{ .ok = line };
+    result.tag = .Ok;
+    return result;
+}
+
+fn stdinLineErr(err: anyerror, roc_host: *abi.RocHost) abi.TryType4 {
+    var result = std.mem.zeroes(abi.TryType4);
+    result.payload = .{ .err = abi.RocStr.fromSlice(@errorName(err), roc_host) };
+    result.tag = .Err;
+    return result;
+}
+
+fn stdoutLineOk() abi.TryType6 {
+    var result = std.mem.zeroes(abi.TryType6);
+    result.tag = .Ok;
+    return result;
+}
+
+fn stdoutLineErr(err: anyerror, roc_host: *abi.RocHost) abi.TryType6 {
+    var result = std.mem.zeroes(abi.TryType6);
+    result.payload = .{ .err = abi.RocStr.fromSlice(@errorName(err), roc_host) };
+    result.tag = .Err;
+    return result;
+}
+
+/// Hosted function: Host.stderr_line!
+fn hostedStderrLine(str: abi.RocStr) callconv(.c) abi.TryType0 {
     const roc_host = g_roc_host.?;
     var owned = str;
     defer owned.decref(roc_host);
@@ -53,12 +93,13 @@ fn hostedStderrLine(str: abi.RocStr) callconv(.c) void {
     const message = owned.asSlice();
     const io = std.Io.Threaded.global_single_threaded.io();
     const stderr = std.Io.File.stderr();
-    stderr.writeStreamingAll(io, message) catch {};
-    stderr.writeStreamingAll(io, "\n") catch {};
+    stderr.writeStreamingAll(io, message) catch |err| return stderrLineErr(err, roc_host);
+    stderr.writeStreamingAll(io, "\n") catch |err| return stderrLineErr(err, roc_host);
+    return stderrLineOk();
 }
 
-/// Hosted function: Stdin.line!
-fn hostedStdinLine() callconv(.c) abi.RocStr {
+/// Hosted function: Host.stdin_line!
+fn hostedStdinLine() callconv(.c) abi.TryType4 {
     const roc_host = g_roc_host.?;
     const roc_env: *abi.RocEnv = @ptrCast(@alignCast(roc_host.env));
     const host: *HostEnv = @fieldParentPtr("roc_env", roc_env);
@@ -66,11 +107,12 @@ fn hostedStdinLine() callconv(.c) abi.RocStr {
 
     var line = while (true) {
         const maybe_line = reader.takeDelimiter('\n') catch |err| switch (err) {
-            error.ReadFailed => break &.{}, // Return empty string on error
+            error.ReadFailed => return stdinLineErr(err, roc_host),
             error.StreamTooLong => {
                 // Skip the overlong line so the next call starts fresh.
                 _ = reader.discardDelimiterInclusive('\n') catch |discard_err| switch (discard_err) {
-                    error.ReadFailed, error.EndOfStream => break &.{},
+                    error.ReadFailed => return stdinLineErr(discard_err, roc_host),
+                    error.EndOfStream => return stdinLineOk(abi.RocStr.empty()),
                 };
                 continue;
             },
@@ -85,14 +127,14 @@ fn hostedStdinLine() callconv(.c) abi.RocStr {
     }
 
     if (line.len == 0) {
-        return abi.RocStr.empty();
+        return stdinLineOk(abi.RocStr.empty());
     }
 
-    return abi.RocStr.fromSlice(line[0..line.len], roc_host);
+    return stdinLineOk(abi.RocStr.fromSlice(line[0..line.len], roc_host));
 }
 
-/// Hosted function: Stdout.line!
-fn hostedStdoutLine(str: abi.RocStr) callconv(.c) void {
+/// Hosted function: Host.stdout_line!
+fn hostedStdoutLine(str: abi.RocStr) callconv(.c) abi.TryType6 {
     const roc_host = g_roc_host.?;
     var owned = str;
     defer owned.decref(roc_host);
@@ -100,8 +142,9 @@ fn hostedStdoutLine(str: abi.RocStr) callconv(.c) void {
     const message = owned.asSlice();
     const io = std.Io.Threaded.global_single_threaded.io();
     const stdout = std.Io.File.stdout();
-    stdout.writeStreamingAll(io, message) catch {};
-    stdout.writeStreamingAll(io, "\n") catch {};
+    stdout.writeStreamingAll(io, message) catch |err| return stdoutLineErr(err, roc_host);
+    stdout.writeStreamingAll(io, "\n") catch |err| return stdoutLineErr(err, roc_host);
+    return stdoutLineOk();
 }
 
 fn hostAlloc(length: usize, alignment: usize) callconv(.c) ?*anyopaque {

--- a/src/roc_platform_abi.zig
+++ b/src/roc_platform_abi.zig
@@ -117,7 +117,7 @@ pub fn allocateBox(
 
 /// Decrement a pointer-aligned boxed payload with no Roc refcounted values.
 pub fn decrefBox(data_ptr: ?*anyopaque, roc_host: *RocHost) void {
-    decrefBoxWith(data_ptr, @alignOf(usize), null, roc_host);
+    decrefBoxWith(data_ptr, @alignOf(usize), false, null, roc_host);
 }
 
 /// Increment a boxed function closure.
@@ -129,7 +129,7 @@ pub fn increfErasedCallable(callable: RocErasedCallable, amount: isize) void {
 /// Decrement a boxed function closure and run its capture drop callback on final release.
 pub fn decrefErasedCallable(callable: RocErasedCallable, roc_host: *RocHost) void {
     const data = callable orelse return;
-    decrefBoxWith(@ptrCast(data), roc_erased_callable_payload_alignment, &dropErasedCallablePayload, roc_host);
+    decrefBoxWith(@ptrCast(data), roc_erased_callable_payload_alignment, false, &dropErasedCallablePayload, roc_host);
 }
 
 fn dropErasedCallablePayload(data_ptr: ?*anyopaque, roc_host: *RocHost) callconv(.c) void {
@@ -142,9 +142,16 @@ fn dropErasedCallablePayload(data_ptr: ?*anyopaque, roc_host: *RocHost) callconv
 }
 
 /// Decrement a boxed payload and run payload teardown when this is the final ref.
+///
+/// `payload_contains_refcounted` must match the value passed to `allocateBox`:
+/// it determines the box header size, and is independent of whether a
+/// `payload_decref` teardown callback is supplied. A host resource handle such
+/// as `Box(U64)` holding a raw pointer has `payload_contains_refcounted = false`
+/// even when it provides a teardown callback to free the underlying resource.
 pub fn decrefBoxWith(
     data_ptr: ?*anyopaque,
     payload_alignment: usize,
+    payload_contains_refcounted: bool,
     payload_decref: ?RocBoxPayloadDecref,
     roc_host: *RocHost,
 ) void {
@@ -155,20 +162,23 @@ pub fn decrefBoxWith(
     const prev = @atomicRmw(isize, rc, .Sub, 1, .monotonic);
     if (prev == 1) {
         if (payload_decref) |callback| callback(data_ptr, roc_host);
-        freeBoxAllocation(data, payload_alignment, payload_decref != null, roc_host);
+        freeBoxAllocation(data, payload_alignment, payload_contains_refcounted, roc_host);
     }
 }
 
 /// Free a boxed payload allocation immediately after running payload teardown.
+///
+/// See `decrefBoxWith` for the meaning of `payload_contains_refcounted`.
 pub fn freeBoxWith(
     data_ptr: ?*anyopaque,
     payload_alignment: usize,
+    payload_contains_refcounted: bool,
     payload_decref: ?RocBoxPayloadDecref,
     roc_host: *RocHost,
 ) void {
     const data = boxDataPtr(data_ptr) orelse return;
     if (payload_decref) |callback| callback(data_ptr, roc_host);
-    freeBoxAllocation(data, payload_alignment, payload_decref != null, roc_host);
+    freeBoxAllocation(data, payload_alignment, payload_contains_refcounted, roc_host);
 }
 
 /// Return true when a boxed payload data pointer has exactly one live ref.
@@ -555,38 +565,187 @@ pub const RocEnv = struct {
 };
 
 /// Tag discriminant for Try.
-pub const TryTag = enum(u8) {
+pub const TryType0Tag = enum(u8) {
     Err = 0,
     Ok = 1,
 };
 
-/// Tag union: Try
-pub const Try = extern struct {
-    payload: extern union {
-        err: i32,
+/// Payload union for Try.
+pub const TryType0Payload = extern union {
+        err: RocStr,
         ok: void,
-    },
-    tag: TryTag,
+};
+
+/// Tag union: Try
+pub const TryType0 = if (@sizeOf(usize) == 4) extern struct {
+    payload: [12]u8 align(4),
+    tag: TryType0Tag,
+    pub fn payload_err(self: *const @This()) RocStr {
+        const ptr: *const RocStr = @ptrCast(@alignCast(&self.payload));
+        return ptr.*;
+    }
+} else extern struct {
+    payload: TryType0Payload,
+    tag: TryType0Tag,
+    pub fn payload_err(self: *const @This()) RocStr {
+        return self.payload.err;
+    }
 };
 
 comptime {
     if (@sizeOf(usize) == 8) {
-        if (@sizeOf(Try) != 8) @compileError("Try size mismatch");
-        if (@alignOf(Try) != 4) @compileError("Try alignment mismatch");
+        if (@sizeOf(TryType0) != 32) @compileError("TryType0 size mismatch");
+        if (@alignOf(TryType0) != 8) @compileError("TryType0 alignment mismatch");
+        if (@offsetOf(TryType0, "tag") != 24) @compileError("TryType0 tag offset mismatch");
+    }
+    if (@sizeOf(usize) == 4) {
+        if (@sizeOf(TryType0) != 16) @compileError("TryType0 size mismatch");
+        if (@alignOf(TryType0) != 4) @compileError("TryType0 alignment mismatch");
+        if (@offsetOf(TryType0, "tag") != 12) @compileError("TryType0 tag offset mismatch");
     }
 }
 
-/// Arguments for Stderr.line!
-/// Roc signature: Str => {}
+/// Tag discriminant for Try.
+pub const TryType4Tag = enum(u8) {
+    Err = 0,
+    Ok = 1,
+};
+
+/// Payload union for Try.
+pub const TryType4Payload = extern union {
+        err: RocStr,
+        ok: RocStr,
+};
+
+/// Tag union: Try
+pub const TryType4 = if (@sizeOf(usize) == 4) extern struct {
+    payload: [12]u8 align(4),
+    tag: TryType4Tag,
+    pub fn payload_err(self: *const @This()) RocStr {
+        const ptr: *const RocStr = @ptrCast(@alignCast(&self.payload));
+        return ptr.*;
+    }
+    pub fn payload_ok(self: *const @This()) RocStr {
+        const ptr: *const RocStr = @ptrCast(@alignCast(&self.payload));
+        return ptr.*;
+    }
+} else extern struct {
+    payload: TryType4Payload,
+    tag: TryType4Tag,
+    pub fn payload_err(self: *const @This()) RocStr {
+        return self.payload.err;
+    }
+    pub fn payload_ok(self: *const @This()) RocStr {
+        return self.payload.ok;
+    }
+};
+
+comptime {
+    if (@sizeOf(usize) == 8) {
+        if (@sizeOf(TryType4) != 32) @compileError("TryType4 size mismatch");
+        if (@alignOf(TryType4) != 8) @compileError("TryType4 alignment mismatch");
+        if (@offsetOf(TryType4, "tag") != 24) @compileError("TryType4 tag offset mismatch");
+    }
+    if (@sizeOf(usize) == 4) {
+        if (@sizeOf(TryType4) != 16) @compileError("TryType4 size mismatch");
+        if (@alignOf(TryType4) != 4) @compileError("TryType4 alignment mismatch");
+        if (@offsetOf(TryType4, "tag") != 12) @compileError("TryType4 tag offset mismatch");
+    }
+}
+
+/// Tag discriminant for Try.
+pub const TryType6Tag = enum(u8) {
+    Err = 0,
+    Ok = 1,
+};
+
+/// Payload union for Try.
+pub const TryType6Payload = extern union {
+        err: RocStr,
+        ok: void,
+};
+
+/// Tag union: Try
+pub const TryType6 = if (@sizeOf(usize) == 4) extern struct {
+    payload: [12]u8 align(4),
+    tag: TryType6Tag,
+    pub fn payload_err(self: *const @This()) RocStr {
+        const ptr: *const RocStr = @ptrCast(@alignCast(&self.payload));
+        return ptr.*;
+    }
+} else extern struct {
+    payload: TryType6Payload,
+    tag: TryType6Tag,
+    pub fn payload_err(self: *const @This()) RocStr {
+        return self.payload.err;
+    }
+};
+
+comptime {
+    if (@sizeOf(usize) == 8) {
+        if (@sizeOf(TryType6) != 32) @compileError("TryType6 size mismatch");
+        if (@alignOf(TryType6) != 8) @compileError("TryType6 alignment mismatch");
+        if (@offsetOf(TryType6, "tag") != 24) @compileError("TryType6 tag offset mismatch");
+    }
+    if (@sizeOf(usize) == 4) {
+        if (@sizeOf(TryType6) != 16) @compileError("TryType6 size mismatch");
+        if (@alignOf(TryType6) != 4) @compileError("TryType6 alignment mismatch");
+        if (@offsetOf(TryType6, "tag") != 12) @compileError("TryType6 tag offset mismatch");
+    }
+}
+
+/// Tag discriminant for Try.
+pub const TryType11Tag = enum(u8) {
+    Err = 0,
+    Ok = 1,
+};
+
+/// Payload union for Try.
+pub const TryType11Payload = extern union {
+        err: i32,
+        ok: void,
+};
+
+/// Tag union: Try
+pub const TryType11 = if (@sizeOf(usize) == 4) extern struct {
+    payload: [4]u8 align(4),
+    tag: TryType11Tag,
+    pub fn payload_err(self: *const @This()) i32 {
+        const ptr: *const i32 = @ptrCast(@alignCast(&self.payload));
+        return ptr.*;
+    }
+} else extern struct {
+    payload: TryType11Payload,
+    tag: TryType11Tag,
+    pub fn payload_err(self: *const @This()) i32 {
+        return self.payload.err;
+    }
+};
+
+comptime {
+    if (@sizeOf(usize) == 8) {
+        if (@sizeOf(TryType11) != 8) @compileError("TryType11 size mismatch");
+        if (@alignOf(TryType11) != 4) @compileError("TryType11 alignment mismatch");
+        if (@offsetOf(TryType11, "tag") != 4) @compileError("TryType11 tag offset mismatch");
+    }
+    if (@sizeOf(usize) == 4) {
+        if (@sizeOf(TryType11) != 8) @compileError("TryType11 size mismatch");
+        if (@alignOf(TryType11) != 4) @compileError("TryType11 alignment mismatch");
+        if (@offsetOf(TryType11, "tag") != 4) @compileError("TryType11 tag offset mismatch");
+    }
+}
+
+/// Arguments for Host.stderr_line!
+/// Roc signature: Str => Try({}, [StderrErr(Str)])
 /// Refcounted fields are owned by the hosted function.
-pub const StderrLineArgs = extern struct {
+pub const HostStderr_lineArgs = extern struct {
     arg0: RocStr,
 };
 
-/// Arguments for Stdout.line!
-/// Roc signature: Str => {}
+/// Arguments for Host.stdout_line!
+/// Roc signature: Str => Try({}, [StdoutErr(Str)])
 /// Refcounted fields are owned by the hosted function.
-pub const StdoutLineArgs = extern struct {
+pub const HostStdout_lineArgs = extern struct {
     arg0: RocStr,
 };
 
@@ -594,8 +753,72 @@ pub const StdoutLineArgs = extern struct {
 // Generated Refcount Helpers
 // =============================================================================
 
-/// Recursively decrement Roc-owned payloads in Try.
-pub fn decrefTry(value: Try, roc_host: *RocHost) void {
+/// Recursively decrement Roc-owned payloads in TryType0.
+pub fn decrefTryType0(value: TryType0, roc_host: *RocHost) void {
+    switch (value.tag) {
+        .Err => {
+        value.payload_err().decref(roc_host);
+        },
+        .Ok => {},
+    }
+}
+
+/// Increment Roc-owned payloads in TryType0.
+pub fn increfTryType0(value: TryType0, amount: isize) void {
+    switch (value.tag) {
+        .Err => {
+        value.payload_err().incref(amount);
+        },
+        .Ok => {},
+    }
+}
+
+/// Recursively decrement Roc-owned payloads in TryType4.
+pub fn decrefTryType4(value: TryType4, roc_host: *RocHost) void {
+    switch (value.tag) {
+        .Err => {
+        value.payload_err().decref(roc_host);
+        },
+        .Ok => {
+        value.payload_ok().decref(roc_host);
+        },
+    }
+}
+
+/// Increment Roc-owned payloads in TryType4.
+pub fn increfTryType4(value: TryType4, amount: isize) void {
+    switch (value.tag) {
+        .Err => {
+        value.payload_err().incref(amount);
+        },
+        .Ok => {
+        value.payload_ok().incref(amount);
+        },
+    }
+}
+
+/// Recursively decrement Roc-owned payloads in TryType6.
+pub fn decrefTryType6(value: TryType6, roc_host: *RocHost) void {
+    switch (value.tag) {
+        .Err => {
+        value.payload_err().decref(roc_host);
+        },
+        .Ok => {},
+    }
+}
+
+/// Increment Roc-owned payloads in TryType6.
+pub fn increfTryType6(value: TryType6, amount: isize) void {
+    switch (value.tag) {
+        .Err => {
+        value.payload_err().incref(amount);
+        },
+        .Ok => {},
+    }
+}
+
+/// Recursively decrement Roc-owned payloads in TryType11.
+pub fn decrefTryType11(value: TryType11, roc_host: *RocHost) void {
     _ = roc_host;
     switch (value.tag) {
         .Err => {},
@@ -603,8 +826,8 @@ pub fn decrefTry(value: Try, roc_host: *RocHost) void {
     }
 }
 
-/// Increment Roc-owned payloads in Try.
-pub fn increfTry(value: Try, amount: isize) void {
+/// Increment Roc-owned payloads in TryType11.
+pub fn increfTryType11(value: TryType11, amount: isize) void {
     _ = amount;
     switch (value.tag) {
         .Err => {},
@@ -633,17 +856,17 @@ pub extern fn roc_crashed(bytes: [*]const u8, len: usize) callconv(.c) void;
 // Refcounted arguments are owned by the hosted function.
 // =============================================================================
 
-/// Hosted symbol for Stderr.line!
-/// Roc signature: Str => {}
-pub extern fn roc_stderr_line(arg0: RocStr) callconv(.c) void;
+/// Hosted symbol for Host.stderr_line!
+/// Roc signature: Str => Try({}, [StderrErr(Str)])
+pub extern fn roc_stderr_line(arg0: RocStr) callconv(.c) TryType0;
 
-/// Hosted symbol for Stdin.line!
-/// Roc signature: {} => Str
-pub extern fn roc_stdin_line() callconv(.c) RocStr;
+/// Hosted symbol for Host.stdin_line!
+/// Roc signature: {} => Try(Str, [StdinErr(Str)])
+pub extern fn roc_stdin_line() callconv(.c) TryType4;
 
-/// Hosted symbol for Stdout.line!
-/// Roc signature: Str => {}
-pub extern fn roc_stdout_line(arg0: RocStr) callconv(.c) void;
+/// Hosted symbol for Host.stdout_line!
+/// Roc signature: Str => Try({}, [StdoutErr(Str)])
+pub extern fn roc_stdout_line(arg0: RocStr) callconv(.c) TryType6;
 
 
 /// Default memory management functions for Roc platforms.


### PR DESCRIPTION
## Summary
- open the platform `main!` error row and route hosted stdio effects through internal `Host.roc` wrappers
- update examples to use local platform paths and propagate stdio errors with `?`
- add Roc API docs comments, `zig build docs`, README badge/docs link, and release docs deployment to GitHub Pages

## Tests
- `zig build test -- --verbose`