### PR TITLE
Use 1.0.0 release URL in examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,12 +14,10 @@ A template for building [Roc platforms](https://www.roc-lang.org/platforms) usin
 
 ## Examples
 
-The examples in this repo use the local platform at `../platform/main.roc`.
+Use the current release bundle as the platform dependency:
 
-For apps outside this repo, build a bundle from this checkout and use that generated bundle URL or file path as the platform dependency. The latest published release bundle may not match the current platform API.
-
-```bash
-./bundle.sh
+```roc
+app [main!] { pf: platform "https://github.com/lukewilliamboswell/roc-platform-template-zig/releases/download/1.0.0/AnZoxzoGPtSGQ15EQh6pBeeaHJ7aizP9MQhK81dES3Uq.tar.zst" }
 ```
 
 Run examples with interpreter: `roc examples/<name>.roc`
@@ -37,6 +35,8 @@ zig build docs
 ```
 
 ## Testing
+
+The checked-in examples use the latest release bundle so they can be copied directly. `zig build test` rewrites temporary copies to use the local `platform/main.roc` before running them.
 
 ```
 $ zig build test

--- a/build.zig
+++ b/build.zig
@@ -145,9 +145,20 @@ pub fn build(b: *std.Build) void {
         }),
     });
 
+    const local_examples_dir = ".zig-cache/local-examples";
+    const prepare_local_examples = b.addSystemCommand(&.{
+        "bash",
+        "ci/prepare_local_examples.sh",
+        local_examples_dir,
+    });
+
     const run_integration = b.addRunArtifact(test_runner);
     // Integration tests need the native platform library to be built first
     run_integration.step.dependOn(&copy_native.step);
+    // The checked-in examples use the latest release URL; local tests should
+    // exercise the platform in this checkout.
+    run_integration.step.dependOn(&prepare_local_examples.step);
+    run_integration.addArgs(&.{ "--examples-dir", ".zig-cache/local-examples/examples" });
     // Run integration after unit tests
     run_integration.step.dependOn(&run_host_tests.step);
     // Pass through args (e.g. --verbose)

--- a/ci/prepare_local_examples.sh
+++ b/ci/prepare_local_examples.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+root_dir="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$root_dir"
+
+work_dir="${1:-.zig-cache/local-examples}"
+examples_out="$work_dir/examples"
+
+rm -rf "$work_dir"
+mkdir -p "$examples_out"
+
+python3 - "$examples_out" <<'PY'
+from pathlib import Path
+import os
+import re
+import sys
+
+examples_out = Path(sys.argv[1])
+source_dir = Path("examples")
+platform_path = Path("platform/main.roc").resolve()
+replacement_path = os.path.relpath(platform_path, examples_out.resolve())
+replacement = f'platform "{Path(replacement_path).as_posix()}"'
+
+platform_pattern = re.compile(
+    r'platform "(?:'
+    r'https://github\.com/lukewilliamboswell/roc-platform-template-zig/releases/download/[^"]+'
+    r'|\.\./platform/main\.roc'
+    r')"'
+)
+
+rewritten = 0
+for source in sorted(source_dir.glob("*.roc")):
+    text = source.read_text(encoding="utf-8")
+    updated, count = platform_pattern.subn(replacement, text, count=1)
+    if count != 1:
+        raise SystemExit(f"example does not use a recognized platform URL: {source}")
+    (examples_out / source.name).write_text(updated, encoding="utf-8")
+    rewritten += 1
+
+if rewritten == 0:
+    raise SystemExit("no examples found to rewrite")
+PY

--- a/ci/test_bundled_examples.sh
+++ b/ci/test_bundled_examples.sh
@@ -107,6 +107,7 @@ bundle_url, out_dir = sys.argv[1], Path(sys.argv[2])
 source_dir = Path("examples")
 replacement = f'platform "{bundle_url}"'
 needles = [
+    'platform "https://github.com/lukewilliamboswell/roc-platform-template-zig/releases/download/1.0.0/AnZoxzoGPtSGQ15EQh6pBeeaHJ7aizP9MQhK81dES3Uq.tar.zst"',
     'platform "https://github.com/lukewilliamboswell/roc-platform-template-zig/releases/download/0.9/8GdFEvQYS3TeAZxKvTzCLVdQiomweGtXcdZkXNDEeABq.tar.zst"',
     'platform "../platform/main.roc"',
 ]

--- a/examples/all_roc_syntax.roc
+++ b/examples/all_roc_syntax.roc
@@ -1,4 +1,4 @@
-app [main!] { pf: platform "../platform/main.roc" }
+app [main!] { pf: platform "https://github.com/lukewilliamboswell/roc-platform-template-zig/releases/download/1.0.0/AnZoxzoGPtSGQ15EQh6pBeeaHJ7aizP9MQhK81dES3Uq.tar.zst" }
 
 import pf.Stdout
 import pf.Stdout as StdoutAlias

--- a/examples/cli_args.roc
+++ b/examples/cli_args.roc
@@ -1,4 +1,4 @@
-app [main!] { pf: platform "../platform/main.roc" }
+app [main!] { pf: platform "https://github.com/lukewilliamboswell/roc-platform-template-zig/releases/download/1.0.0/AnZoxzoGPtSGQ15EQh6pBeeaHJ7aizP9MQhK81dES3Uq.tar.zst" }
 
 import pf.Stdout
 

--- a/examples/dbg_test.roc
+++ b/examples/dbg_test.roc
@@ -1,4 +1,4 @@
-app [main!] { pf: platform "../platform/main.roc" }
+app [main!] { pf: platform "https://github.com/lukewilliamboswell/roc-platform-template-zig/releases/download/1.0.0/AnZoxzoGPtSGQ15EQh6pBeeaHJ7aizP9MQhK81dES3Uq.tar.zst" }
 
 import pf.Stdout
 

--- a/examples/echo.roc
+++ b/examples/echo.roc
@@ -1,4 +1,4 @@
-app [main!] { pf: platform "../platform/main.roc" }
+app [main!] { pf: platform "https://github.com/lukewilliamboswell/roc-platform-template-zig/releases/download/1.0.0/AnZoxzoGPtSGQ15EQh6pBeeaHJ7aizP9MQhK81dES3Uq.tar.zst" }
 
 import pf.Stdin
 import pf.Stdout

--- a/examples/echo_multiline.roc
+++ b/examples/echo_multiline.roc
@@ -1,4 +1,4 @@
-app [main!] { pf: platform "../platform/main.roc" }
+app [main!] { pf: platform "https://github.com/lukewilliamboswell/roc-platform-template-zig/releases/download/1.0.0/AnZoxzoGPtSGQ15EQh6pBeeaHJ7aizP9MQhK81dES3Uq.tar.zst" }
 
 import pf.Stdin
 import pf.Stdout

--- a/examples/exit.roc
+++ b/examples/exit.roc
@@ -1,4 +1,4 @@
-app [main!] { pf: platform "../platform/main.roc" }
+app [main!] { pf: platform "https://github.com/lukewilliamboswell/roc-platform-template-zig/releases/download/1.0.0/AnZoxzoGPtSGQ15EQh6pBeeaHJ7aizP9MQhK81dES3Uq.tar.zst" }
 
 import pf.Stdout
 

--- a/examples/fizzbuzz.roc
+++ b/examples/fizzbuzz.roc
@@ -1,4 +1,4 @@
-app [main!] { pf: platform "../platform/main.roc" }
+app [main!] { pf: platform "https://github.com/lukewilliamboswell/roc-platform-template-zig/releases/download/1.0.0/AnZoxzoGPtSGQ15EQh6pBeeaHJ7aizP9MQhK81dES3Uq.tar.zst" }
 
 import pf.Stdout
 

--- a/examples/hello_world.roc
+++ b/examples/hello_world.roc
@@ -1,4 +1,4 @@
-app [main!] { pf: platform "../platform/main.roc" }
+app [main!] { pf: platform "https://github.com/lukewilliamboswell/roc-platform-template-zig/releases/download/1.0.0/AnZoxzoGPtSGQ15EQh6pBeeaHJ7aizP9MQhK81dES3Uq.tar.zst" }
 
 import pf.Stdout
 

--- a/examples/match.roc
+++ b/examples/match.roc
@@ -1,4 +1,4 @@
-app [main!] { pf: platform "../platform/main.roc" }
+app [main!] { pf: platform "https://github.com/lukewilliamboswell/roc-platform-template-zig/releases/download/1.0.0/AnZoxzoGPtSGQ15EQh6pBeeaHJ7aizP9MQhK81dES3Uq.tar.zst" }
 
 import pf.Stdout
 

--- a/examples/stderr.roc
+++ b/examples/stderr.roc
@@ -1,4 +1,4 @@
-app [main!] { pf: platform "../platform/main.roc" }
+app [main!] { pf: platform "https://github.com/lukewilliamboswell/roc-platform-template-zig/releases/download/1.0.0/AnZoxzoGPtSGQ15EQh6pBeeaHJ7aizP9MQhK81dES3Uq.tar.zst" }
 
 import pf.Stdout
 import pf.Stderr

--- a/examples/sum_fold.roc
+++ b/examples/sum_fold.roc
@@ -1,4 +1,4 @@
-app [main!] { pf: platform "../platform/main.roc" }
+app [main!] { pf: platform "https://github.com/lukewilliamboswell/roc-platform-template-zig/releases/download/1.0.0/AnZoxzoGPtSGQ15EQh6pBeeaHJ7aizP9MQhK81dES3Uq.tar.zst" }
 
 import pf.Stdout
 

--- a/examples/tests.roc
+++ b/examples/tests.roc
@@ -1,4 +1,4 @@
-app [main!] { pf: platform "../platform/main.roc" }
+app [main!] { pf: platform "https://github.com/lukewilliamboswell/roc-platform-template-zig/releases/download/1.0.0/AnZoxzoGPtSGQ15EQh6pBeeaHJ7aizP9MQhK81dES3Uq.tar.zst" }
 
 import pf.Stdout
 


### PR DESCRIPTION
## Summary
- update checked-in examples and README to use the 1.0.0 release bundle URL
- teach bundled-example tests to recognize the 1.0.0 URL
- add local example rewriting so `zig build test` and `ci/all_tests.sh` exercise this checkout's `platform/main.roc` instead of the release bundle

## Tests
- `bash ci/all_tests.sh`