### PR TITLE
Build and attest independent Linux runtime releases

### DIFF
--- a/.github/workflows/runtime.yml
+++ b/.github/workflows/runtime.yml
@@ -30,7 +30,10 @@ jobs:
         with:
           persist-credentials: false
       - name: Install upstream signature verifier
-        run: sudo apt-get update && sudo apt-get install -y minisign
+        run: |
+          PACKAGE=$(python3 -c 'import json; print(json.load(open("runtime/sources.json"))["objcopy"]["package"])')
+          sudo apt-get update
+          sudo apt-get install -y minisign "$PACKAGE"
       - name: Test runtime tooling
         run: python3 -m unittest discover -s scripts -p 'test_runtime_tools.py' -v
       - name: Build from verified sources
@@ -74,7 +77,10 @@ jobs:
           name: runtime-1
           path: .zig-cache/runtime-dist
       - name: Install upstream signature verifier
-        run: sudo apt-get update && sudo apt-get install -y minisign
+        run: |
+          PACKAGE=$(python3 -c 'import json; print(json.load(open("runtime/sources.json"))["objcopy"]["package"])')
+          sudo apt-get update
+          sudo apt-get install -y minisign "$PACKAGE"
       - name: Test startup and libc without implicit runtime libraries
         env:
           VERSION: ${{ needs.build.outputs.version }}

--- a/.github/workflows/runtime.yml
+++ b/.github/workflows/runtime.yml
@@ -1,0 +1,143 @@
+name: Runtime release
+
+on:
+  pull_request:
+    paths:
+      - 'runtime/**'
+      - 'scripts/*runtime*.py'
+      - '.github/workflows/runtime.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: runtime-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: Build runtime (${{ matrix.copy }})
+    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        copy: [1, 2]
+    outputs:
+      version: ${{ steps.metadata.outputs.version }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Install upstream signature verifier
+        run: sudo apt-get update && sudo apt-get install -y minisign
+      - name: Test runtime tooling
+        run: python3 -m unittest discover -s scripts -p 'test_runtime_tools.py' -v
+      - name: Build from verified sources
+        run: python3 scripts/build_runtime.py build --output .zig-cache/runtime-dist
+      - name: Read release version
+        id: metadata
+        run: |
+          VERSION=$(python3 -c 'import json; print(json.load(open("runtime/sources.json"))["runtime_version"])')
+          [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: runtime-${{ matrix.copy }}
+          path: .zig-cache/runtime-dist/*
+          if-no-files-found: error
+
+  reproducibility:
+    needs: build
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: runtime-*
+      - name: Compare independent builds
+        run: diff -r runtime-1 runtime-2
+
+  test:
+    name: Test runtime (${{ matrix.os }})
+    needs: build
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-24.04, ubuntu-24.04-arm]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: runtime-1
+          path: .zig-cache/runtime-dist
+      - name: Install upstream signature verifier
+        run: sudo apt-get update && sudo apt-get install -y minisign
+      - name: Test startup and libc without implicit runtime libraries
+        env:
+          VERSION: ${{ needs.build.outputs.version }}
+        run: python3 scripts/build_runtime.py smoke ".zig-cache/runtime-dist/roc-runtime-$VERSION.tar.gz"
+      - uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2.2.1
+        with:
+          version: 0.16.0
+          use-cache: false
+      - name: Read compiler requirement
+        run: |
+          PIN=$(python3 scripts/roc_version.py)
+          echo "ROC_NIGHTLY_TAG=$PIN" >> "$GITHUB_ENV"
+      - uses: roc-lang/setup-roc@cbe782d6f165b89c87d99f50a59ac4f5f73b4427
+        with:
+          version: nightly-new-compiler
+          nightly-tag: ${{ env.ROC_NIGHTLY_TAG }}
+      - name: Test Roc platform with candidate runtime and baseline CPU targets
+        env:
+          VERSION: ${{ needs.build.outputs.version }}
+        run: python3 scripts/test_runtime_platform.py ".zig-cache/runtime-dist/roc-runtime-$VERSION.tar.gz"
+
+  publish:
+    needs: [build, reproducibility, test]
+    if: github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+      id-token: write
+      attestations: write
+    env:
+      VERSION: ${{ needs.build.outputs.version }}
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      # Never check out or execute the built source in the signing job.
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: runtime-1
+          path: dist
+      - name: Check artifact integrity
+        working-directory: dist
+        run: sha256sum -c SHA256SUMS
+      - name: Attest build provenance
+        id: provenance
+        uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4.2.2
+        with:
+          subject-path: dist/roc-runtime-${{ env.VERSION }}.tar.gz
+      - name: Attest SBOM
+        id: sbom
+        uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4.2.2
+        with:
+          subject-path: dist/roc-runtime-${{ env.VERSION }}.tar.gz
+          sbom-path: dist/runtime.spdx.json
+      - name: Publish immutable runtime release
+        env:
+          PROVENANCE: ${{ steps.provenance.outputs.bundle-path }}
+          SBOM_ATTESTATION: ${{ steps.sbom.outputs.bundle-path }}
+        run: |
+          cp "$PROVENANCE" dist/provenance.sigstore.json
+          cp "$SBOM_ATTESTATION" dist/sbom.sigstore.json
+          TAG="runtime-$VERSION"
+          # Creating a ref fails if that version has already been used.
+          gh api --method POST "repos/$GITHUB_REPOSITORY/git/refs" -f "ref=refs/tags/$TAG" -f "sha=$GITHUB_SHA"
+          printf 'Linux runtime %s built from verified Zig 0.16.0 sources.\n\nProducer commit: %s\n\nSee runtime.spdx.json, SHA256SUMS and the attached Sigstore bundles.\n' "$VERSION" "$GITHUB_SHA" > notes.md
+          gh release create "$TAG" dist/* --repo "$GITHUB_REPOSITORY" --draft --verify-tag --latest=false --title "Runtime $VERSION" --notes-file notes.md
+          gh release edit "$TAG" --repo "$GITHUB_REPOSITORY" --draft=false --latest=false
+          gh release view "$TAG" --repo "$GITHUB_REPOSITORY" --json isImmutable --jq '.isImmutable' | grep -qx true

--- a/runtime/README.md
+++ b/runtime/README.md
@@ -4,11 +4,11 @@
 Minisign key. The producer verifies both before executing Zig and compiling its
 bundled musl, Zig libc and compiler runtime. This does not bootstrap Zig itself.
 
-The archive contains baseline x86-64 and ARM64 Linux runtime files, a per-file
+The archive strips build-path-bearing debug data with LLVM objcopy and contains baseline x86-64 and ARM64 Linux runtime files, a per-file
 manifest, and license notices. Zig 0.16.0 supplies musl 1.2.5 with Zig-specific
 changes; the SBOM does not describe this as unmodified upstream musl.
 
-To reproduce on Linux, install Python 3.10+ and Minisign, then run:
+To reproduce on Linux, install Python 3.10+, Minisign and LLVM 18.1.3 (`llvm-objcopy-18`), then run:
 
 ```sh
 python3 scripts/build_runtime.py build --output .zig-cache/runtime-dist

--- a/runtime/README.md
+++ b/runtime/README.md
@@ -1,0 +1,40 @@
+# Independently released Linux runtime
+
+`sources.json` pins the official Zig distribution, its SHA-256 and upstream
+Minisign key. The producer verifies both before executing Zig and compiling its
+bundled musl, Zig libc and compiler runtime. This does not bootstrap Zig itself.
+
+The archive contains baseline x86-64 and ARM64 Linux runtime files, a per-file
+manifest, and license notices. Zig 0.16.0 supplies musl 1.2.5 with Zig-specific
+changes; the SBOM does not describe this as unmodified upstream musl.
+
+To reproduce on Linux, install Python 3.10+ and Minisign, then run:
+
+```sh
+python3 scripts/build_runtime.py build --output .zig-cache/runtime-dist
+python3 scripts/build_runtime.py smoke .zig-cache/runtime-dist/roc-runtime-1.0.0.tar.gz
+```
+
+Output directories must be new. Two independent CI builds must produce identical
+archives and SBOMs. Native x86-64 and ARM64 jobs test startup, allocation, math,
+threads, TLS and stdio with only the archive's runtime libraries. Candidate Roc
+tests use temporary platform copies, including baseline target builds.
+
+After a reviewed producer change merges to `main`, manually dispatch **Runtime
+release**. Compilation and testing have read-only permissions. The publishing
+job performs no source checkout, signs provenance and SPDX SBOM attestations for
+the tested archive, and publishes a draft only after attaching all assets.
+Enable repository release immutability before the first publication. Runtime
+tags use `runtime-VERSION` and never become the latest platform release.
+
+Versions live in `sources.json` and advance through reviewed changes independently
+of Roc nightlies. Existing tags and releases are never overwritten. If a run
+fails after reserving a tag or creating a draft, inspect the existing state and
+prepare a reviewed recovery; rerunning does not replace it automatically.
+
+The initial producer leaves the historical runtime files in Git until the first
+published archive and its attestations have been verified. The consumer migration
+then removes those files going forward, without rewriting Git history.
+
+Attestations prove the recorded build identity and artifact integrity. They do
+not constitute an OpenSSF certification or an asserted SLSA level.

--- a/runtime/smoke.c
+++ b/runtime/smoke.c
@@ -1,0 +1,43 @@
+#include <assert.h>
+#include <errno.h>
+#include <math.h>
+#include <pthread.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static _Thread_local int tls_value = 7;
+static void *worker(void *unused) {
+    (void)unused;
+    assert(tls_value == 7);
+    tls_value = 19;
+    errno = ERANGE;
+    return NULL;
+}
+
+int main(int argc, char **argv) {
+    assert(argc > 0 && argv[0]);
+    char *memory = malloc(256);
+    assert(memory);
+    strcpy(memory, "runtime");
+    assert(strlen(memory) == 7);
+    memory = realloc(memory, 512);
+    assert(memory && strcmp(memory, "runtime") == 0);
+    free(memory);
+    volatile double input = 9.0;
+    assert(fabs(sqrt(input) - 3.0) < 0.0001);
+    pthread_t thread;
+    assert(pthread_create(&thread, NULL, worker, NULL) == 0);
+    assert(pthread_join(thread, NULL) == 0);
+    assert(tls_value == 7);
+    FILE *stream = tmpfile();
+    assert(stream);
+    assert(fputs("verified runtime", stream) >= 0);
+    rewind(stream);
+    char buffer[32];
+    assert(fgets(buffer, sizeof buffer, stream));
+    assert(strcmp(buffer, "verified runtime") == 0);
+    assert(fclose(stream) == 0);
+    puts("runtime smoke passed");
+    return 0;
+}

--- a/runtime/sources.json
+++ b/runtime/sources.json
@@ -1,0 +1,23 @@
+{
+  "schema": 1,
+  "runtime_version": "1.0.0",
+  "zig_version": "0.16.0",
+  "musl_version": "1.2.5",
+  "zig_minisign_key": "RWSGOq2NVecA2UPNdBUZykf1CCb147pkmdtYxgb3Ti+JO/wCYvhbAb/U",
+  "toolchains": {
+    "x86_64-linux": {
+      "url": "https://ziglang.org/download/0.16.0/zig-x86_64-linux-0.16.0.tar.xz",
+      "sha256": "70e49664a74374b48b51e6f3fdfbf437f6395d42509050588bd49abe52ba3d00"
+    },
+    "aarch64-linux": {
+      "url": "https://ziglang.org/download/0.16.0/zig-aarch64-linux-0.16.0.tar.xz",
+      "sha256": "ea4b09bfb22ec6f6c6ceac57ab63efb6b46e17ab08d21f69f3a48b38e1534f17"
+    }
+  },
+  "targets": {
+    "x64musl": "x86_64-linux-musl",
+    "arm64musl": "aarch64-linux-musl"
+  },
+  "cpu": "baseline",
+  "optimization": "-O2"
+}

--- a/runtime/sources.json
+++ b/runtime/sources.json
@@ -19,5 +19,11 @@
     "arm64musl": "aarch64-linux-musl"
   },
   "cpu": "baseline",
-  "optimization": "-O2"
+  "optimization": "-O2",
+  "objcopy": {
+    "command": "llvm-objcopy-18",
+    "version": "18.1.3",
+    "package": "llvm-18=1:18.1.3-1ubuntu1",
+    "source": "https://archive.ubuntu.com/ubuntu/pool/universe/l/llvm-toolchain-18/"
+  }
 }

--- a/scripts/build_runtime.py
+++ b/scripts/build_runtime.py
@@ -77,7 +77,7 @@ def normalize_archive(zig: Path, source: Path, destination: Path, work: Path):
         obj = work / f"{index:04d}.o"
         obj.write_bytes(subprocess.check_output([zig, "ar", "pP", source, member]))
         stripped = work / f"stripped-{index:04d}.o"
-        run([zig, "objcopy", "--strip-debug", obj, stripped])
+        run(["llvm-objcopy-18", "--strip-debug", obj, stripped])
         objects.append(stripped)
     run([zig, "ar", "rcsD", destination, *objects])
 
@@ -99,12 +99,18 @@ def sbom(stage: Path, manifest: dict, archive: Path, epoch: int) -> dict:
     compiler = manifest["sources"]["toolchains"][manifest["builder_platform"]]
     packages[-1]["downloadLocation"] = compiler["url"]
     packages[-1]["checksums"] = [{"algorithm": "SHA256", "checksumValue": compiler["sha256"]}]
+    packages.append({"SPDXID": "SPDXRef-objcopy", "name": "LLVM objcopy",
+                     "versionInfo": manifest["sources"]["objcopy"]["version"],
+                     "downloadLocation": manifest["sources"]["objcopy"]["source"],
+                     "filesAnalyzed": False, "licenseConcluded": "NOASSERTION",
+                     "licenseDeclared": "Apache-2.0 WITH LLVM-exception", "copyrightText": "NOASSERTION"})
     packages[0]["checksums"] = [{"algorithm": "SHA256", "checksumValue": digest(archive)}]
     files, relationships = [], [{"spdxElementId": "SPDXRef-DOCUMENT", "relationshipType": "DESCRIBES", "relatedSpdxElement": "SPDXRef-runtime"}]
     for ident in ("musl", "zig-libc", "compiler-rt"):
         relationships.append({"spdxElementId": "SPDXRef-runtime", "relationshipType": "DEPENDS_ON", "relatedSpdxElement": f"SPDXRef-{ident}"})
     relationships.append({"spdxElementId": "SPDXRef-zig", "relationshipType": "BUILD_TOOL_OF", "relatedSpdxElement": "SPDXRef-runtime"})
     inventory = {**manifest["files"], "manifest.json": digest(stage / "manifest.json")}
+    relationships.append({"spdxElementId": "SPDXRef-objcopy", "relationshipType": "BUILD_TOOL_OF", "relatedSpdxElement": "SPDXRef-runtime"})
     for index, (name, sha) in enumerate(sorted(inventory.items())):
         ident = f"SPDXRef-file-{index}"
         files.append({"SPDXID": ident, "fileName": "./" + name,
@@ -121,6 +127,9 @@ def sbom(stage: Path, manifest: dict, archive: Path, epoch: int) -> dict:
 
 def build(output: Path):
     lock = json.loads(SOURCES.read_text())
+    version = subprocess.check_output([lock["objcopy"]["command"], "--version"], text=True)
+    if lock["objcopy"]["version"] not in version:
+        raise ValueError("Unexpected llvm-objcopy version")
     output.mkdir(parents=True, exist_ok=False)
     cache_root = ROOT / ".zig-cache"
     cache_root.mkdir(exist_ok=True)
@@ -145,7 +154,7 @@ def build(output: Path):
                     objects.mkdir()
                     normalize_archive(zig, source, target_out / filename, objects)
                 else:
-                    run([zig, "objcopy", "--strip-debug", source, target_out / filename])
+                    run(["llvm-objcopy-18", "--strip-debug", source, target_out / filename])
         (stage / "licenses").mkdir()
         shutil.copyfile(zig.parent / "LICENSE", stage / "licenses/Zig.txt")
         shutil.copyfile(zig.parent / "lib/libc/musl/COPYRIGHT", stage / "licenses/musl.txt")

--- a/scripts/build_runtime.py
+++ b/scripts/build_runtime.py
@@ -1,0 +1,203 @@
+#!/usr/bin/env python3
+"""Build the independently versioned runtime from a verified Zig distribution."""
+from __future__ import annotations
+
+import argparse
+from datetime import datetime, timezone
+import gzip
+import json
+import os
+from pathlib import Path
+import platform
+import shlex
+import shutil
+import subprocess
+import tarfile
+import tempfile
+import urllib.request
+
+from runtime_common import ROOT, RUNTIME_FILES, digest, safe_extract, write_json, validate_tree
+
+SOURCES = ROOT / "runtime/sources.json"
+
+
+def run(args, **kwargs):
+    return subprocess.run([str(a) for a in args], check=True, **kwargs)
+
+
+def toolchain(work: Path, lock: dict) -> Path:
+    machine = {"x86_64": "x86_64", "aarch64": "aarch64"}.get(platform.machine())
+    if platform.system() != "Linux" or machine is None:
+        raise ValueError("The runtime producer requires x86-64 or ARM64 Linux")
+    source = lock["toolchains"][f"{machine}-linux"]
+    archive = work / "zig.tar.xz"
+    urllib.request.urlretrieve(source["url"], archive)
+    if digest(archive) != source["sha256"]:
+        raise ValueError("Zig distribution checksum mismatch")
+    signature = work / "zig.minisig"
+    urllib.request.urlretrieve(source["url"] + ".minisig", signature)
+    run(["minisign", "-Vm", archive, "-x", signature, "-P", lock["zig_minisign_key"]])
+    installed = work / "toolchain"
+    safe_extract(archive, installed)
+    executables = list(installed.glob("*/zig"))
+    if len(executables) != 1:
+        raise ValueError("Unexpected Zig distribution layout")
+    zig = executables[0]
+    if subprocess.check_output([zig, "version"], text=True).strip() != lock["zig_version"]:
+        raise ValueError("Zig executable version mismatch")
+    return zig
+
+
+def link_inputs(log: str, cache: Path) -> dict[str, Path]:
+    lines = [line for line in log.splitlines() if line.startswith("ld.lld ") and " -r " not in line]
+    if len(lines) != 1:
+        raise ValueError("Expected exactly one Zig linker invocation:\n" + log)
+    result = {}
+    for token in shlex.split(lines[0])[1:]:
+        path = Path(token)
+        if not path.is_absolute():
+            path = cache.parent / path
+        if path.name in RUNTIME_FILES:
+            if path.name in result or not path.resolve().is_relative_to(cache.resolve()) or not path.is_file():
+                raise ValueError(f"Unexpected runtime linker input: {token}")
+            result[path.name] = path
+        elif token.endswith(".a"):
+            raise ValueError(f"Unexpected linker library: {token}")
+    if set(result) != set(RUNTIME_FILES):
+        raise ValueError(f"Incomplete Zig runtime inputs: {result.keys()}")
+    return result
+
+
+def normalize_archive(zig: Path, source: Path, destination: Path, work: Path):
+    """Zig's archives contain cache paths; rebuild with stable member names."""
+    members = subprocess.check_output([zig, "ar", "t", source], text=True).splitlines()
+    objects = []
+    for index, member in enumerate(members):
+        # Inputs are compiler output in our isolated cache, never downloaded code.
+        obj = work / f"{index:04d}.o"
+        obj.write_bytes(subprocess.check_output([zig, "ar", "pP", source, member]))
+        stripped = work / f"stripped-{index:04d}.o"
+        run([zig, "objcopy", "--strip-debug", obj, stripped])
+        objects.append(stripped)
+    run([zig, "ar", "rcsD", destination, *objects])
+
+
+def sbom(stage: Path, manifest: dict, archive: Path, epoch: int) -> dict:
+    version = manifest["version"]
+    packages = []
+    for ident, name, ver, license_name in [
+        ("runtime", "roc-platform-linux-runtime", version, "NOASSERTION"),
+        ("musl", "musl (Zig distribution)", manifest["sources"]["musl_version"], "NOASSERTION"),
+        ("zig-libc", "Zig libc", manifest["sources"]["zig_version"], "MIT"),
+        ("compiler-rt", "Zig compiler runtime", manifest["sources"]["zig_version"], "MIT"),
+        ("zig", "Zig compiler distribution", manifest["sources"]["zig_version"], "NOASSERTION"),
+    ]:
+        packages.append({"SPDXID": f"SPDXRef-{ident}", "name": name, "versionInfo": ver,
+                         "downloadLocation": "https://ziglang.org/download/0.16.0/" if ident != "runtime" else "NOASSERTION",
+                         "filesAnalyzed": False, "licenseConcluded": "NOASSERTION", "licenseDeclared": license_name,
+                         "copyrightText": "NOASSERTION"})
+    compiler = manifest["sources"]["toolchains"][manifest["builder_platform"]]
+    packages[-1]["downloadLocation"] = compiler["url"]
+    packages[-1]["checksums"] = [{"algorithm": "SHA256", "checksumValue": compiler["sha256"]}]
+    packages[0]["checksums"] = [{"algorithm": "SHA256", "checksumValue": digest(archive)}]
+    files, relationships = [], [{"spdxElementId": "SPDXRef-DOCUMENT", "relationshipType": "DESCRIBES", "relatedSpdxElement": "SPDXRef-runtime"}]
+    for ident in ("musl", "zig-libc", "compiler-rt"):
+        relationships.append({"spdxElementId": "SPDXRef-runtime", "relationshipType": "DEPENDS_ON", "relatedSpdxElement": f"SPDXRef-{ident}"})
+    relationships.append({"spdxElementId": "SPDXRef-zig", "relationshipType": "BUILD_TOOL_OF", "relatedSpdxElement": "SPDXRef-runtime"})
+    inventory = {**manifest["files"], "manifest.json": digest(stage / "manifest.json")}
+    for index, (name, sha) in enumerate(sorted(inventory.items())):
+        ident = f"SPDXRef-file-{index}"
+        files.append({"SPDXID": ident, "fileName": "./" + name,
+                      "checksums": [{"algorithm": "SHA256", "checksumValue": sha}],
+                      "licenseConcluded": "NOASSERTION", "licenseInfoInFiles": ["NOASSERTION"], "copyrightText": "NOASSERTION"})
+        relationships.append({"spdxElementId": "SPDXRef-runtime", "relationshipType": "CONTAINS", "relatedSpdxElement": ident})
+    return {"spdxVersion": "SPDX-2.3", "dataLicense": "CC0-1.0", "SPDXID": "SPDXRef-DOCUMENT",
+            "name": f"roc-platform-runtime-{version}",
+            "documentNamespace": f"https://spdx.org/spdxdocs/roc-runtime-{digest(archive)}",
+            "creationInfo": {"created": datetime.fromtimestamp(epoch, timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+                             "creators": ["Tool: roc-platform-template-zig-runtime-builder"]},
+            "packages": packages, "files": files, "relationships": relationships}
+
+
+def build(output: Path):
+    lock = json.loads(SOURCES.read_text())
+    output.mkdir(parents=True, exist_ok=False)
+    cache_root = ROOT / ".zig-cache"
+    cache_root.mkdir(exist_ok=True)
+    with tempfile.TemporaryDirectory(prefix="runtime-build-", dir=cache_root) as tmp:
+        work = Path(tmp)
+        zig = toolchain(work, lock)
+        cache = work / "cache"
+        env = {**os.environ, "ZIG_GLOBAL_CACHE_DIR": str(cache), "ZIG_LOCAL_CACHE_DIR": str(work / "local")}
+        stage = work / "stage"
+        commands = {}
+        for name, target in lock["targets"].items():
+            target_out = stage / "targets" / name
+            target_out.mkdir(parents=True)
+            # stdin has stable contents and no absolute source path. -g0 avoids debug paths.
+            flags = ["cc", "-target", target, "-mcpu=" + lock["cpu"], "-static", lock["optimization"], "-g0"]
+            result = run([zig, *flags, "-x", "c", "-", "-o", work / f"probe-{name}", "-v"],
+                         input="int main(void) { return 0; }\n", text=True, capture_output=True, env=env, cwd=work)
+            commands[name] = ["zig", *flags, "-x", "c", "-", "-o", "probe", "-v"]
+            for filename, source in link_inputs(result.stderr, cache).items():
+                if filename.endswith(".a"):
+                    objects = work / f"objects-{name}-{filename}"
+                    objects.mkdir()
+                    normalize_archive(zig, source, target_out / filename, objects)
+                else:
+                    run([zig, "objcopy", "--strip-debug", source, target_out / filename])
+        (stage / "licenses").mkdir()
+        shutil.copyfile(zig.parent / "LICENSE", stage / "licenses/Zig.txt")
+        shutil.copyfile(zig.parent / "lib/libc/musl/COPYRIGHT", stage / "licenses/musl.txt")
+        sha = subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=ROOT, text=True).strip()
+        epoch = int(subprocess.check_output(["git", "show", "-s", "--format=%ct", "HEAD"], cwd=ROOT))
+        manifest = {"schema": 1, "version": lock["runtime_version"], "source_commit": sha,
+                    "sources": lock, "commands": commands, "builder_platform": platform.machine() + "-linux",
+                    "files": {p.relative_to(stage).as_posix(): digest(p) for p in sorted(stage.rglob("*")) if p.is_file()}}
+        write_json(stage / "manifest.json", manifest)
+        validate_tree(stage)
+        archive = output / f"roc-runtime-{lock['runtime_version']}.tar.gz"
+        with archive.open("wb") as raw, gzip.GzipFile(fileobj=raw, mode="wb", filename="", mtime=0) as gz:
+            with tarfile.open(fileobj=gz, mode="w", format=tarfile.USTAR_FORMAT) as tar:
+                for path in sorted(stage.rglob("*")):
+                    if path.is_file():
+                        info = tarfile.TarInfo(path.relative_to(stage).as_posix())
+                        info.size, info.mode, info.mtime = path.stat().st_size, 0o644, 0
+                        with path.open("rb") as stream:
+                            tar.addfile(info, stream)
+        write_json(output / "runtime.spdx.json", sbom(stage, manifest, archive, epoch))
+        (output / "SHA256SUMS").write_text("".join(f"{digest(p)}  {p.name}\n" for p in sorted(output.iterdir()) if p.is_file()))
+        print(f"Built {archive}: {digest(archive)}", flush=True)
+
+
+def smoke(archive: Path):
+    lock = json.loads(SOURCES.read_text())
+    with tempfile.TemporaryDirectory(prefix="runtime-smoke-", dir=ROOT / ".zig-cache") as tmp:
+        work = Path(tmp)
+        zig = toolchain(work, lock)
+        stage = work / "runtime"
+        from runtime_common import runtime_members
+        safe_extract(archive, stage, expected=runtime_members())
+        validate_tree(stage)
+        name = {"x86_64": "x64musl", "aarch64": "arm64musl"}[platform.machine()]
+        target = lock["targets"][name]
+        obj, binary = work / "smoke.o", work / "smoke"
+        run([zig, "cc", "-target", target, "-mcpu=baseline", "-O2", "-c", ROOT / "runtime/smoke.c", "-o", obj])
+        libs = stage / "targets" / name
+        # Direct LLD invocation ensures there is no implicit host/toolchain libc.
+        run([zig, "ld.lld", "-static", "-o", binary, libs / "crt1.o", obj,
+             "--start-group", *(libs / f for f in RUNTIME_FILES[1:]), "--end-group"])
+        run([binary])
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description=__doc__)
+    sub = parser.add_subparsers(dest="command", required=True)
+    sub.add_parser("build").add_argument("--output", type=Path, required=True)
+    sub.add_parser("smoke").add_argument("archive", type=Path)
+    args = parser.parse_args()
+    if args.command == "build":
+        build(args.output.resolve())
+    else:
+        (ROOT / ".zig-cache").mkdir(exist_ok=True)
+        smoke(args.archive.resolve())

--- a/scripts/runtime_common.py
+++ b/scripts/runtime_common.py
@@ -1,0 +1,76 @@
+"""Archive and inventory primitives shared by runtime producer and consumer."""
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path, PurePosixPath
+import tarfile
+
+ROOT = Path(__file__).resolve().parents[1]
+RUNTIME_FILES = ("crt1.o", "libc.a", "libzigc.a", "libcompiler_rt.a")
+TARGETS = ("x64musl", "arm64musl")
+LICENSES = ("licenses/Zig.txt", "licenses/musl.txt")
+
+
+def digest(path: Path) -> str:
+    with path.open("rb") as stream:
+        value = hashlib.sha256()
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            value.update(chunk)
+        return value.hexdigest()
+
+
+def write_json(path: Path, value: object) -> None:
+    path.write_text(json.dumps(value, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def safe_extract(archive: Path, destination: Path, *, expected: set[str] | None = None) -> None:
+    """Accept regular files/directories only, never links or ambiguous paths."""
+    with tarfile.open(archive) as tar:
+        seen: set[str] = set()
+        members = tar.getmembers()
+        total = 0
+        for member in members:
+            path = PurePosixPath(member.name)
+            if (path.is_absolute() or ".." in path.parts or "\\" in member.name
+                    or ":" in member.name or not path.parts or member.name in seen
+                    or path.as_posix() != member.name.rstrip("/")
+                    or not (member.isfile() or member.isdir())):
+                raise ValueError(f"Unsafe archive member: {member.name}")
+            seen.add(member.name)
+            if expected is not None and (not member.isfile() or member.name not in expected):
+                raise ValueError(f"Unexpected archive member: {member.name}")
+            total += member.size
+            if total > 2_000_000_000:
+                raise ValueError("Archive exceeds extraction size limit")
+        if expected is not None and seen != expected:
+            raise ValueError(f"Incomplete runtime archive: {expected - seen}")
+        # Paths and types were checked above; use explicit writes for Python 3.10+.
+        for member in members:
+            path = destination / member.name
+            if member.isdir():
+                path.mkdir(parents=True, exist_ok=True)
+            else:
+                path.parent.mkdir(parents=True, exist_ok=True)
+                with tar.extractfile(member) as source, path.open("wb") as output:
+                    import shutil
+                    shutil.copyfileobj(source, output)
+                path.chmod(member.mode & 0o777)
+
+
+def runtime_members() -> set[str]:
+    return {f"targets/{target}/{name}" for target in TARGETS for name in RUNTIME_FILES} | set(LICENSES) | {"manifest.json"}
+
+
+def validate_tree(directory: Path) -> dict:
+    manifest = json.loads((directory / "manifest.json").read_text())
+    expected = runtime_members() - {"manifest.json"}
+    if manifest.get("schema") != 1 or set(manifest.get("files", {})) != expected:
+        raise ValueError("Invalid runtime inventory")
+    actual = {p.relative_to(directory).as_posix() for p in directory.rglob("*") if p.is_file()}
+    if actual != runtime_members() or any(p.is_symlink() for p in directory.rglob("*")):
+        raise ValueError("Unexpected runtime contents")
+    for name, checksum in manifest["files"].items():
+        if digest(directory / name) != checksum:
+            raise ValueError(f"Runtime file hash mismatch: {name}")
+    return manifest

--- a/scripts/test_runtime_platform.py
+++ b/scripts/test_runtime_platform.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+"""Test candidate runtime archives without changing the committed platform."""
+import json
+from pathlib import Path
+import platform
+import shutil
+import subprocess
+import sys
+import tempfile
+
+from runtime_common import ROOT, RUNTIME_FILES, safe_extract, runtime_members, validate_tree
+
+
+def main(archive):
+    (ROOT / ".zig-cache").mkdir(exist_ok=True)
+    with tempfile.TemporaryDirectory(prefix="runtime-platform-", dir=ROOT / ".zig-cache") as tmp:
+        work = Path(tmp)
+        for name in ("src", "scripts", "ci", "examples"):
+            shutil.copytree(ROOT / name, work / name, ignore=shutil.ignore_patterns("__pycache__"))
+        for name in ("build.zig", "build.zig.zon"):
+            shutil.copyfile(ROOT / name, work / name)
+        (work / "platform").mkdir()
+        for source in (ROOT / "platform").glob("*.roc"):
+            shutil.copyfile(source, work / "platform" / source.name)
+        runtime = work / "runtime"
+        safe_extract(archive, runtime, expected=runtime_members())
+        validate_tree(runtime)
+        for target in ("x64musl", "x64v1musl", "arm64musl", "arm64v1musl"):
+            dest = work / "platform/targets" / target
+            dest.mkdir(parents=True)
+            for name in RUNTIME_FILES:
+                shutil.copyfile(runtime / "targets" / target.replace("v1", "") / name, dest / name)
+        header = work / "platform/main.roc"
+        header.write_text(header.read_text().replace('"libc.a"]', '"libc.a", "libzigc.a", "libcompiler_rt.a"]'))
+        build = work / "build.zig"
+        build.write_text(build.read_text().replace('host_lib.bundle_compiler_rt = true;', 'host_lib.bundle_compiler_rt = target.result.os.tag != .linux;'))
+        subprocess.run(["zig", "build", "test"], cwd=work, check=True)
+        baseline = {"x86_64": "x64v1musl", "aarch64": "arm64v1musl"}[platform.machine()]
+        spec_path = work / "scripts/test_spec.json"
+        spec = json.loads(spec_path.read_text())
+        for app in spec["apps"]:
+            app.setdefault("build_args", []).append("--target=" + baseline)
+        spec_path.write_text(json.dumps(spec))
+        subprocess.run([sys.executable, "scripts/test.py", "--examples-dir", ".zig-cache/local-examples/examples"], cwd=work, check=True)
+
+
+if __name__ == "__main__":
+    main(Path(sys.argv[1]).resolve())

--- a/scripts/test_runtime_tools.py
+++ b/scripts/test_runtime_tools.py
@@ -1,0 +1,64 @@
+import io
+import json
+from pathlib import Path
+import tarfile
+import tempfile
+import unittest
+
+from build_runtime import link_inputs
+from runtime_common import digest, runtime_members, safe_extract, validate_tree, write_json
+
+
+class RuntimeTests(unittest.TestCase):
+    def test_tar_rejects_unsafe_and_incomplete_inputs(self):
+        for name, kind in [("../escape", tarfile.REGTYPE), ("/absolute", tarfile.REGTYPE),
+                           ("C:/escape", tarfile.REGTYPE), ("targets/link", tarfile.SYMTYPE),
+                           ("targets/hard", tarfile.LNKTYPE), ("unexpected", tarfile.REGTYPE)]:
+            with self.subTest(name=name), tempfile.TemporaryDirectory() as temp:
+                root = Path(temp)
+                archive = root / "test.tar"
+                with tarfile.open(archive, "w") as tar:
+                    info = tarfile.TarInfo(name)
+                    info.type = kind
+                    info.linkname = "elsewhere" if kind != tarfile.REGTYPE else ""
+                    tar.addfile(info, io.BytesIO())
+                with self.assertRaises(ValueError):
+                    safe_extract(archive, root / "out", expected=runtime_members())
+                self.assertFalse((root / "out").exists())
+
+    def test_duplicate_archive_member(self):
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            archive = root / "duplicate.tar"
+            with tarfile.open(archive, "w") as tar:
+                for _ in range(2):
+                    tar.addfile(tarfile.TarInfo("manifest.json"), io.BytesIO())
+            with self.assertRaises(ValueError):
+                safe_extract(archive, root / "out")
+
+    def test_cached_file_integrity(self):
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            files = runtime_members() - {"manifest.json"}
+            for name in files:
+                path = root / name
+                path.parent.mkdir(parents=True, exist_ok=True)
+                path.write_bytes(b"fixture")
+            manifest = {"schema": 1, "files": {name: digest(root / name) for name in files}}
+            write_json(root / "manifest.json", manifest)
+            self.assertEqual(validate_tree(root), manifest)
+            (root / "targets/x64musl/libc.a").write_bytes(b"modified")
+            with self.assertRaisesRegex(ValueError, "hash mismatch"):
+                validate_tree(root)
+
+    def test_linker_inputs_cannot_escape_cache(self):
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            with self.assertRaises(ValueError):
+                link_inputs("ld.lld -o probe /etc/libc.a", root / "cache")
+            with self.assertRaises(ValueError):
+                link_inputs("ld.lld -o probe cache/libunknown.a", root / "cache")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Introduce a manually dispatched runtime release workflow that builds baseline x86-64 and ARM64 Linux runtimes from a checksum- and Minisign-verified official Zig distribution. Runtime versions are independent of platform releases and never become the latest platform release.

Two isolated builds must match byte-for-byte. Native Linux jobs exercise startup/libc and the Roc examples with default and baseline targets. A separate job signs provenance and SPDX SBOM attestations and publishes the exact artifacts through a draft release. Existing tags cannot be overwritten.

The producer includes source locks, per-file hashes, license notices and defensive archive validation. Existing tracked runtime binaries remain until the first runtime release is published and verified; the consumer migration follows separately.

Validation: Python tooling tests and actionlint pass. Local candidate C smoke and Roc tests passed on x86-64; clean-build reproducibility and native ARM64 checks are required in CI. Repository immutability will be enabled before the first publication.
