### PR TITLE
Enable protected automatic nightly merges

### DIFF
--- a/.github/roc-nightly.json
+++ b/.github/roc-nightly.json
@@ -18,5 +18,5 @@
     "examples/sum_fold/main.roc",
     "examples/tests/main.roc"
   ],
-  "auto_merge": false
+  "auto_merge": true
 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,3 +115,20 @@ jobs:
 
       - name: Test committed release URLs with a fresh cache
         run: python3 scripts/test_published_examples.py
+
+  ci-required:
+    name: CI required
+    if: always()
+    needs: [tooling, build, published-examples]
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Require every validation lane to pass
+        env:
+          RESULTS: ${{ toJSON(needs.*.result) }}
+        run: |
+          python3 - <<'PYCODE'
+          import json, os
+          results = json.loads(os.environ["RESULTS"])
+          if len(results) != 3 or any(result != "success" for result in results):
+              raise SystemExit(f"Required validation failed: {results}")
+          PYCODE

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -331,3 +331,20 @@ jobs:
       - name: Deploy docs
         id: deployment
         uses: actions/deploy-pages@368f82528645a54fb793d4d04e342629a3f51346 # v5.0.1
+
+  bundle-required:
+    name: Bundle required
+    if: always()
+    needs: [build-and-bundle, test-bundle, build-docs]
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Require every validation lane to pass
+        env:
+          RESULTS: ${{ toJSON(needs.*.result) }}
+        run: |
+          python3 - <<'PYCODE'
+          import json, os
+          results = json.loads(os.environ["RESULTS"])
+          if len(results) != 3 or any(result != "success" for result in results):
+              raise SystemExit(f"Required validation failed: {results}")
+          PYCODE

--- a/ci/MAINTAINING.md
+++ b/ci/MAINTAINING.md
@@ -58,15 +58,21 @@ The September 7 updater failed at PR creation, before compiler validation:
 [failed run](https://github.com/lukewilliamboswell/roc-platform-template-zig/actions/runs/34151289741).
 Actions PR creation was disabled. The combined GitHub setting for creating and
 approving PRs has now been enabled; default token permissions remain read-only.
-The controller never approves its own PRs, and `auto_merge` is explicitly false.
-The repository currently allows all Actions and has no effective rules on `main`.
+The controller never approves its own PRs. `auto_merge` is enabled for signed,
+compiler-pin-only candidates after both configured validation workflows pass.
+The active `main` ruleset requires PRs, up-to-date `CI required` and `Bundle required`
+checks from GitHub Actions, verified signatures, and protects against deletion and
+force pushes. It has no bypass actors and requires zero human approvals so nightly
+updates can merge unattended. This review-count policy applies to all PRs; source
+and workflow changes still require maintainer review as project policy.
 
-After merging these changes, manually dispatch Update Roc nightly. Verify the
-signed candidate commit, both CI lanes and release archive jobs against that SHA.
-Then exercise a no-op and retain failure evidence showing unsuccessful updates
-remain unmerged. These live trials have not been completed by local validation.
-
-Before enabling automatic merging, install and verify strict required-check and
-PR rules with no bot bypass, following the shared integration guide. Select real
-check names from successful runs. Do not infer protected-merge acceptance from a
-successful dispatch or enable automatic merging merely to report statuses.
+Both aggregate jobs run even after a dependency fails or is skipped and accept only
+success from every lane. The controller mirrors their actual candidate results to
+required statuses, then rechecks the base, head, signatures, and pin-only diff before
+an immediate squash merge. Failed updates stay open. Set `auto_merge` to false to
+stop automatic merging; disable the updater workflow for an immediate stop.
+The repository allows all Actions; workflow dependencies remain pinned to reviewed
+full commit SHAs. After changing this setup, manually dispatch Update Roc nightly
+and verify the signed candidate, both configured workflow runs, and bot merge.
+Repeat the dispatch to check the no-op path. Never infer protected-merge acceptance
+from a successful validation dispatch alone.


### PR DESCRIPTION
Enable unattended signed compiler-pin updates after exact-candidate source, published-example, and bundle validation. Add always-running `CI required` and `Bundle required` aggregate checks that reject failed, cancelled, or skipped dependencies.

Rollout installs a strict main ruleset requiring these GitHub Actions checks, PRs and verified signatures, preventing deletion and force pushes, with no bypass actors. Zero required human approvals permits unattended nightlies and applies to all PRs; source/workflow changes retain maintainer review policy.

Validation: actionlint and git diff --check passed. Full PR CI and a live bot merge/no-op trial follow before completion. No release publication is part of this change.
